### PR TITLE
Updated model files to be compatible with the new ME cat function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__
 .idea
 outputs/
 *.pyc
+*.ply
+*.pth

--- a/model/resunet.py
+++ b/model/resunet.py
@@ -165,21 +165,21 @@ class ResUNet2(ME.MinkowskiNetwork):
     out = self.block4_tr(out)
     out_s4_tr = MEF.relu(out)
 
-    out = ME.cat((out_s4_tr, out_s4))
+    out = ME.cat(out_s4_tr, out_s4)
 
     out = self.conv3_tr(out)
     out = self.norm3_tr(out)
     out = self.block3_tr(out)
     out_s2_tr = MEF.relu(out)
 
-    out = ME.cat((out_s2_tr, out_s2))
+    out = ME.cat(out_s2_tr, out_s2)
 
     out = self.conv2_tr(out)
     out = self.norm2_tr(out)
     out = self.block2_tr(out)
     out_s1_tr = MEF.relu(out)
 
-    out = ME.cat((out_s1_tr, out_s1))
+    out = ME.cat(out_s1_tr, out_s1)
     out = self.conv1_tr(out)
     out = MEF.relu(out)
     out = self.final(out)

--- a/model/simpleunet.py
+++ b/model/simpleunet.py
@@ -110,13 +110,13 @@ class SimpleNet(ME.MinkowskiNetwork):
     out = self.norm3_tr(out)
     out_s2_tr = MEF.relu(out)
 
-    out = ME.cat((out_s2_tr, out_s2))
+    out = ME.cat(out_s2_tr, out_s2)
 
     out = self.conv2_tr(out)
     out = self.norm2_tr(out)
     out_s1_tr = MEF.relu(out)
 
-    out = ME.cat((out_s1_tr, out_s1))
+    out = ME.cat(out_s1_tr, out_s1)
     out = self.conv1_tr(out)
     out = self.norm1_tr(out)
     out = MEF.relu(out)
@@ -273,19 +273,19 @@ class SimpleNet2(ME.MinkowskiNetwork):
     out = self.norm4_tr(out)
     out_s4_tr = MEF.relu(out)
 
-    out = ME.cat((out_s4_tr, out_s4))
+    out = ME.cat(out_s4_tr, out_s4)
 
     out = self.conv3_tr(out)
     out = self.norm3_tr(out)
     out_s2_tr = MEF.relu(out)
 
-    out = ME.cat((out_s2_tr, out_s2))
+    out = ME.cat(out_s2_tr, out_s2)
 
     out = self.conv2_tr(out)
     out = self.norm2_tr(out)
     out_s1_tr = MEF.relu(out)
 
-    out = ME.cat((out_s1_tr, out_s1))
+    out = ME.cat(out_s1_tr, out_s1)
     out = self.conv1_tr(out)
     out = self.norm1_tr(out)
     out = MEF.relu(out)
@@ -475,25 +475,25 @@ class SimpleNet3(ME.MinkowskiNetwork):
     out = self.norm5_tr(out)
     out_s8_tr = MEF.relu(out)
 
-    out = ME.cat((out_s8_tr, out_s8))
+    out = ME.cat(out_s8_tr, out_s8)
 
     out = self.conv4_tr(out)
     out = self.norm4_tr(out)
     out_s4_tr = MEF.relu(out)
 
-    out = ME.cat((out_s4_tr, out_s4))
+    out = ME.cat(out_s4_tr, out_s4)
 
     out = self.conv3_tr(out)
     out = self.norm3_tr(out)
     out_s2_tr = MEF.relu(out)
 
-    out = ME.cat((out_s2_tr, out_s2))
+    out = ME.cat(out_s2_tr, out_s2)
 
     out = self.conv2_tr(out)
     out = self.norm2_tr(out)
     out_s1_tr = MEF.relu(out)
 
-    out = ME.cat((out_s1_tr, out_s1))
+    out = ME.cat(out_s1_tr, out_s1)
     out = self.conv1_tr(out)
 
     if self.normalize_feature:


### PR DESCRIPTION
As shown here:
https://github.com/StanfordVL/MinkowskiEngine/blob/17640f161d926dac39a0f2a98b616cf4181025bd/MinkowskiEngine/MinkowskiOps.py#L49

The newer versions of ME make use of *sparce_tensors as opposed to a single tuple value.

I also added the ply and pth files to the .gitignore so that the models downloaded by the demo file are not commited