### PR TITLE
Fix demo.py MEv0.5 compatibility & visualization issues

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -43,9 +43,11 @@ def demo(config):
   vis_pcd = o3d.geometry.PointCloud()
   vis_pcd.points = o3d.utility.Vector3dVector(xyz_down)
 
+  
   vis_pcd = get_colored_point_cloud_feature(vis_pcd,
                                             feature.detach().cpu().numpy(),
-                                            config.voxel_size)
+                                            config.voxel_size,
+                                            config.custom_points)
   o3d.visualization.draw_geometries([vis_pcd])
 
 
@@ -68,6 +70,12 @@ if __name__ == '__main__':
       default=0.025,
       type=float,
       help='voxel size to preprocess point cloud')
+  parser.add_argument(
+      '--custom_points',
+      default=False, 
+      type=bool,
+      help='if the points should be visualized with a custom sphere mesh'
+  )
 
   config = parser.parse_args()
   demo(config)

--- a/util/misc.py
+++ b/util/misc.py
@@ -78,8 +78,8 @@ def extract_features(model,
 
   # Voxelize xyz and feats
   coords = np.floor(xyz / voxel_size)
-  inds = ME.utils.sparse_quantize(coords, return_index=True)
-  coords = coords[inds]
+  coords, inds = ME.utils.sparse_quantize(coords, return_index=True)
+  
   # Convert to batched coords compatible with ME
   coords = ME.utils.batched_coordinates([coords])
   return_coords = xyz[inds]

--- a/util/visualization.py
+++ b/util/visualization.py
@@ -27,14 +27,17 @@ def mesh_sphere(pcd, voxel_size, sphere_size=0.6):
   return spheres
 
 
-def get_colored_point_cloud_feature(pcd, feature, voxel_size):
+def get_colored_point_cloud_feature(pcd, feature, voxel_size, custom_points):
   tsne_results = embed_tsne(feature)
 
   color = get_color_map(tsne_results)
   pcd.colors = o3d.utility.Vector3dVector(color)
-  spheres = mesh_sphere(pcd, voxel_size)
-
-  return spheres
+  if custom_points:
+    # Points are represented by a primitive sphere based on the voxel size.
+    return mesh_sphere(pcd, voxel_size)
+  else:
+    # Here the default point primitive in Open3D is used.
+    return pcd
 
 
 def embed_tsne(data):


### PR DESCRIPTION
The demo does not run on ME v0.5 due to how `sparse_quantize` works. 
v0.4: `return unique_map` 
v0.5: `return discrete_coords[unique_map], unique_map` 

Hence I updated `demo.py` to be v0.5 compatible. 

I also had the issue that the Open3D visualization crashed when using the custom point cloud sphere primitives.
Therefore I added an option to use the default Open3D point cloud primitives instead. 

Otherwise: Awesome work! It's amazing to see that some researchers care about their repos even after the paper is published! :) 